### PR TITLE
Add helper methods on SDK services that accept varargs

### DIFF
--- a/src/main/java/com/mnubo/java/sdk/client/services/EventsSDKServices.java
+++ b/src/main/java/com/mnubo/java/sdk/client/services/EventsSDKServices.java
@@ -3,6 +3,7 @@ package com.mnubo.java.sdk.client.services;
 import static com.mnubo.java.sdk.client.Constants.OBJECT_PATH;
 import static com.mnubo.java.sdk.client.utils.ValidationUtils.notBlank;
 import static com.mnubo.java.sdk.client.utils.ValidationUtils.notNullNorEmpty;
+import static java.util.Arrays.*;
 
 import java.util.List;
 
@@ -36,6 +37,8 @@ class EventsSDKServices implements EventsSDK {
         return sdkCommonServices.postRequest(url, List.class, events);
     }
 
+
+
     @Override
     public List<Result> send(List<Event> events) {
 
@@ -47,5 +50,11 @@ class EventsSDKServices implements EventsSDK {
                                             .build().toString();
 
         return sdkCommonServices.postRequest(url, List.class, events);
+    }
+
+    @Override
+    public List<Result> send(Event... events) {
+
+        return send(asList(events));
     }
 }

--- a/src/main/java/com/mnubo/java/sdk/client/services/ObjectsSDKServices.java
+++ b/src/main/java/com/mnubo/java/sdk/client/services/ObjectsSDKServices.java
@@ -3,6 +3,7 @@ package com.mnubo.java.sdk.client.services;
 import static com.mnubo.java.sdk.client.Constants.OBJECT_PATH;
 import static com.mnubo.java.sdk.client.utils.ValidationUtils.notBlank;
 import static com.mnubo.java.sdk.client.utils.ValidationUtils.validNotNull;
+import static java.util.Arrays.*;
 
 import java.util.List;
 
@@ -66,4 +67,10 @@ class ObjectsSDKServices implements ObjectsSDK {
 
         return sdkCommonServices.putRequest(url, objects, List.class);
     }
+
+    @Override
+    public List<Result> createUpdate(SmartObject... objects) {
+        return createUpdate(asList(objects));
+    }
+
 }

--- a/src/main/java/com/mnubo/java/sdk/client/services/OwnersSDKServices.java
+++ b/src/main/java/com/mnubo/java/sdk/client/services/OwnersSDKServices.java
@@ -2,6 +2,7 @@ package com.mnubo.java.sdk.client.services;
 
 import static com.mnubo.java.sdk.client.utils.ValidationUtils.notBlank;
 import static com.mnubo.java.sdk.client.utils.ValidationUtils.validNotNull;
+import static java.util.Arrays.*;
 
 import java.util.List;
 
@@ -78,5 +79,10 @@ class OwnersSDKServices implements OwnersSDK {
                                             .build().toString();
 
         return sdkCommonServices.putRequest(url, owners, List.class);
+    }
+
+    @Override
+    public List<Result> createUpdate(Owner... owners) {
+        return createUpdate(asList(owners));
     }
 }

--- a/src/main/java/com/mnubo/java/sdk/client/spi/EventsSDK.java
+++ b/src/main/java/com/mnubo/java/sdk/client/spi/EventsSDK.java
@@ -31,4 +31,11 @@ public interface EventsSDK {
      * message.
      */
     List<Result> send(List<Event> events);
+
+    /**
+     * @see EventsSDK#send(List)
+     * @param events
+     * @return
+     */
+    List<Result> send(Event... events);
 }

--- a/src/main/java/com/mnubo/java/sdk/client/spi/ObjectsSDK.java
+++ b/src/main/java/com/mnubo/java/sdk/client/spi/ObjectsSDK.java
@@ -43,4 +43,11 @@ public interface ObjectsSDK {
      * message.
      */
     List<Result> createUpdate(List<SmartObject> objects);
+
+    /**
+     * @see ObjectsSDK#createUpdate(List)
+     * @param objects
+     * @return
+     */
+    List<Result> createUpdate(SmartObject... objects);
 }

--- a/src/main/java/com/mnubo/java/sdk/client/spi/OwnersSDK.java
+++ b/src/main/java/com/mnubo/java/sdk/client/spi/OwnersSDK.java
@@ -51,4 +51,11 @@ public interface OwnersSDK {
      * message.
      */
     List<Result> createUpdate(List<Owner> owners);
+
+    /**
+     * @see OwnersSDK#createUpdate(List)
+     * @param owners
+     * @return
+     */
+    List<Result> createUpdate(Owner... owners);
 }

--- a/src/test/java/com/mnubo/java/sdk/client/services/EventsSDKServicesTest.java
+++ b/src/test/java/com/mnubo/java/sdk/client/services/EventsSDKServicesTest.java
@@ -56,13 +56,13 @@ public class EventsSDKServicesTest extends AbstractServiceTest {
         validateResult(results);
     }
 
-
     @Test
-    public void postListEventListNullThenFail() {
+    public void postVarargEventThenOk() {
+        Event event = Event.builder().withEventType("test_type").build();
 
-        expectedException.expect(IllegalStateException.class);
-        expectedException.expectMessage("Event list cannot be null or empty.");
-        objectClient.send(null);
+        List<Result> results = objectClient.send(event);
+
+        validateResult(results);
     }
 
     @Test

--- a/src/test/java/com/mnubo/java/sdk/client/services/ObjectsSDKServicesTest.java
+++ b/src/test/java/com/mnubo/java/sdk/client/services/ObjectsSDKServicesTest.java
@@ -200,11 +200,12 @@ public class ObjectsSDKServicesTest extends AbstractServiceTest {
     }
 
     @Test
-    public void createUpdateNullThenFail() {
+    public void createUpdateWithVarargThenOk() {
+        SmartObject smartObject = SmartObject.builder().withObjectType("type").withDeviceId("device1").build();
 
-        expectedException.expect(IllegalStateException.class);
-        expectedException.expectMessage("List of smart objects body cannot be null.");
-        objectClient.createUpdate(null);
+        List<Result> results = objectClient.createUpdate(smartObject);
+
+        validateResult(results);
     }
 
     private void validateResult(List<Result> results) {

--- a/src/test/java/com/mnubo/java/sdk/client/services/OwnersSDKServicesTest.java
+++ b/src/test/java/com/mnubo/java/sdk/client/services/OwnersSDKServicesTest.java
@@ -240,12 +240,14 @@ public class OwnersSDKServicesTest extends AbstractServiceTest {
     }
 
     @Test
-    public void createUpdateNullThenFail() {
+    public void createUpdateWithVarargThenOk() {
+        Owner owner = Owner.builder().withUsername("user1").build();
 
-        expectedException.expect(IllegalStateException.class);
-        expectedException.expectMessage("List of owners body cannot be null.");
-        ownerClient.createUpdate(null);
+        List<Result> results = ownerClient.createUpdate(owner);
+
+        validateResult(results);
     }
+
 
     private void validateResult(List<Result> results) {
         assertThat(results.size(), equalTo(4));


### PR DESCRIPTION
…ra method signature that accepts varargs.

This avoids ugly Arrays.asList(event) when there is a single object being written.

The "null" tests were removed because a compilation error occurs in those instances.